### PR TITLE
Future-proof ij1-patcher for ImageJ 1.49m

### DIFF
--- a/src/main/java/net/imagej/patcher/LegacyExtensions.java
+++ b/src/main/java/net/imagej/patcher/LegacyExtensions.java
@@ -226,7 +226,9 @@ class LegacyExtensions {
 			"$_ = $0.equals($1) || $0.startsWith($1 + \"-\") || $0.startsWith($1 + \" -\");");
 
 		// make sure Rhino gets the correct class loader
-		hacker.insertAtTopOfMethod("JavaScriptEvaluator", "public void run()",
+		final String javascript = hacker.existsClass("JavaScriptEvaluator") ?
+			"JavaScriptEvaluator" : "ij.plugin.JavaScriptEvaluator";
+		hacker.insertAtTopOfMethod(javascript, "public void run()",
 			"Thread.currentThread().setContextClassLoader(ij.IJ.getClassLoader());");
 
 		// make sure that the check for Bio-Formats is correct


### PR DESCRIPTION
This commit addresses the problem arising from ImageJ's version 1.49m
simply moving the JavaScriptEvaluator class into the ij.plugin package
with the following explanation:

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
