### PR TITLE
Do not scan jars/ folder for IJ1 plugins

### DIFF
--- a/src/main/java/net/imagej/patcher/EssentialLegacyHooks.java
+++ b/src/main/java/net/imagej/patcher/EssentialLegacyHooks.java
@@ -99,22 +99,6 @@ public class EssentialLegacyHooks extends LegacyHooks {
 	}
 
 	/**
-	 * Intended for sole use with {@link LegacyExtensions#noPluginClassLoader(CodeHacker)}.
-	 */
-	void addThisLoadersClasspath() {
-		final StringBuilder errors = new java.lang.StringBuilder();
-		final ClassLoader loader = Thread.currentThread().getContextClassLoader();
-		final ClassLoader extLoader =
-			ClassLoader.getSystemClassLoader().getParent();
-		for (final File file : getClasspathElements(loader, errors, extLoader)) {
-			addPluginClasspath(file);
-		}
-		if (errors.length() > 0) {
-			System.err.println(errors.toString());
-		}
-	}
-
-	/**
 	 * Intended for sole use with patches in {@link ij.IJ}. DO NOT USE.
 	 */
 	public static ClassLoader missingSubdirs(final ClassLoader loader, final boolean addPluginsDir) {

--- a/src/main/java/net/imagej/patcher/LegacyExtensions.java
+++ b/src/main/java/net/imagej/patcher/LegacyExtensions.java
@@ -306,7 +306,7 @@ class LegacyExtensions {
 	 * Install a hook to optionally run a Runnable at the end of Help>Refresh Menus.
 	 * 
 	 * <p>
-	 * See {@link LegacyExtensions#runAfterRefreshMenus(Runnable)}.
+	 * See {@link LegacyHooks#runAfterRefreshMenus()}.
 	 * </p>
 	 * 
 	 * @param hacker the {@link CodeHacker} to use for patching

--- a/src/main/java/net/imagej/patcher/LegacyExtensions.java
+++ b/src/main/java/net/imagej/patcher/LegacyExtensions.java
@@ -844,8 +844,6 @@ class LegacyExtensions {
 			supportBarePlugins +
 			"}" +
 			"return _classLoader;");
-		hacker.insertAtTopOfMethod(LegacyInjector.ESSENTIAL_LEGACY_HOOKS_CLASS,
-			"public <init>()", "addThisLoadersClasspath();");
 		disableRefreshMenus(hacker);
 
 		// make sure that IJ#runUserPlugIn can execute package-less plugins in subdirectories of $IJ/plugin/


### PR DESCRIPTION
JAR files in the `jars/` subtree are not intended to house ImageJ 1.x plugins. That's what the `plugins/` subtree (i.e., `plugins.dir`) is for. It's also what the `ij1.plugin.dirs` property (supported by ImageJ2 only) is for. The `jars/` subtree is specifically to house libraries that are _not_ IJ1 plugins.

So let's not add the entire classpath to ImageJ1's _plugin_ classpath!

### Additional details

@jburel and I noticed that the Ice libraries bundled with the [OMERO.insight-ij download](http://downloads.openmicroscopy.org/omero/5.0.8/artifacts/OMERO.insight-ij-5.0.8-ice35-b60.zip) (`libs/ice.jar`, `libs/ice-glacier2.jar`, `libs/ice-grid.jar`, and `libs/ice-storm.jar`) were causing spurious submenus to appear in ImageJ's `Plugins` folder (specifically: Plugins > Ice, Plugins > IceGrid, Plugins > IceInternal, Plugins > IceMX and Plugins > IceStorm).

Essentially, the reason is that ImageJ tries very hard to discover ImageJ 1.x plugins embedded within JAR files. It is supposed to be the case that JAR files are only considered to contain ImageJ 1.x plugins if:

* The JAR lives in `plugins/` (not `jars/`)
* The JAR has an underscore in the name
* The JAR has a `plugins.config` file defining its plugins

However, there is also some logic to more aggressively discover plugins, to support packaging that does not conform to the above requirements. ImageJ has a "plugin classpath" where it looks for IJ1 plugins, and it scans the names of all class files within JARs under that plugin classpath. Since the Ice JARs have classes with an underscore in the name, inside a single subfolder within the JAR (e.g., IceGrid), these classes are then interpreted as ImageJ 1.x plugins.

The JARs in the `jars/` folder are not supposed to be processed in this way, but for the past few months there has been a bug in ImageJ2 causing the `jars/` folder to be scanned as well. Consequently, moving the ice libraries into `jars/` was not enough to avoid this issue.

This PR intends to fix that bug.

There is a remaining question whether there is some ImageJ2-specific logic for handling ImageJ 1.x plugins that is causing these Ice-related entries to appear when the Ice JARs dwell beneath `plugins/`, but regardless it is best not to put those library JARs there, so I'm not going to worry about that for now.