### PR TITLE
Fix the bug of using a macro in headless mode that if a checkbox is true...

### DIFF
--- a/src/main/java/net/imagej/patcher/HeadlessGenericDialog.java
+++ b/src/main/java/net/imagej/patcher/HeadlessGenericDialog.java
@@ -282,7 +282,7 @@ public class HeadlessGenericDialog {
 	 * @return the boolean value
 	 */
 	private static boolean getMacroParameter(String label, boolean defaultValue) {
-		return findBooleanMacroParameter(label) || defaultValue;
+		return findBooleanMacroParameter(label);
 	}
 
 	/**


### PR DESCRIPTION
... by default, there is no way to un-check it. If a macro is called normally (no --headless), a checkbox's value will be true if its name appearing in the macro, otherwise the value will be false. It doesn't matter what the default value is.