### PR TITLE
Make plugins with DialogListeners work correctly in headless mode

### DIFF
--- a/src/main/java/net/imagej/patcher/HeadlessGenericDialog.java
+++ b/src/main/java/net/imagej/patcher/HeadlessGenericDialog.java
@@ -204,11 +204,7 @@ public class HeadlessGenericDialog {
 	public void showDialog() {
 		if (Macro.getOptions() == null)
 			throw new RuntimeException("Cannot run dialog headlessly");
-		numberfieldIndex = 0;
-		stringfieldIndex = 0;
-		checkboxIndex = 0;
-		choiceIndex = 0;
-		textAreaIndex = 0;
+		resetCounters();
 
 		// NB: ImageJ 1.x has logic to call the first DialogListener at least once,
 		// in case the plugin _only_ updates its values via the dialogItemChanged
@@ -216,7 +212,19 @@ public class HeadlessGenericDialog {
 		if (listener != null) {
 			// NB: Thanks to Javassist, this class _will_ be a GenericDialog object.
 			listener.dialogItemChanged((ij.gui.GenericDialog) (Object) this, null);
+			resetCounters();
 		}
+	}
+
+    /**
+     * Resets the counters before reading the dialog parameters.
+     */
+	private void resetCounters() {
+		numberfieldIndex = 0;
+		stringfieldIndex = 0;
+		checkboxIndex = 0;
+		choiceIndex = 0;
+		textAreaIndex = 0;
 	}
 
 	public boolean wasCanceled() {

--- a/src/test/java/net/imagej/patcher/HeadlessEnvironmentTest.java
+++ b/src/test/java/net/imagej/patcher/HeadlessEnvironmentTest.java
@@ -123,6 +123,16 @@ public class HeadlessEnvironmentTest {
 	}
 
 	@Test
+	public void testPluginWithDialogListener() throws Exception {
+		final LegacyEnvironment ij1 = getTestEnvironment(true, false);
+		ij1.addPluginClasspath(HeadlessEnvironmentTest.class.getClassLoader());
+		ij1.setMacroOptions("please=123");
+		final String value = ij1.runPlugIn(
+				Plugin_With_DialogListener.class.getName(), "").toString();
+		assertEquals("value: 123\nevent: null\nfinal value: 123\n", value);
+	}
+
+	@Test
 	public void saveDialog() throws Exception {
 		assertTrue(runExamplePlugin(true, "SaveDialog", "file=README.txt", "true"));
 	}

--- a/src/test/java/net/imagej/patcher/HeadlessEnvironmentTest.java
+++ b/src/test/java/net/imagej/patcher/HeadlessEnvironmentTest.java
@@ -43,7 +43,6 @@ import ij.Macro;
 
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
-import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -69,7 +68,6 @@ public class HeadlessEnvironmentTest {
 
 	private String threadName;
 	private ClassLoader threadLoader;
-	private File tmpDir;
 
 	@Before
 	public void saveThreadName() {

--- a/src/test/java/net/imagej/patcher/Plugin_With_DialogListener.java
+++ b/src/test/java/net/imagej/patcher/Plugin_With_DialogListener.java
@@ -1,0 +1,91 @@
+package net.imagej.patcher;
+
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+import ij.gui.DialogListener;
+import ij.gui.GenericDialog;
+import ij.plugin.PlugIn;
+
+import java.awt.AWTEvent;
+
+/**
+ * Tests that {@link Plugin}s with {@link DialogListener}s work correctly in
+ * headless mode.
+ */
+public class Plugin_With_DialogListener implements PlugIn {
+	private final StringBuilder builder = new StringBuilder();
+
+	/**
+	 * Performs the plugin's functionality.
+	 *
+	 * @param arg
+	 *            ignored
+	 */
+	@Override
+	public void run(final String arg) {
+		final GenericDialog gd = new GenericDialog("Let's test this");
+		gd.addStringField("Please enter some text", "<change this>");
+
+		/**
+		 * Listens for changes in the dialog values.
+		 * <p>
+		 * Note: any dialog value that is *not* enquired in this listener will
+		 * *not* be recorded, either. This is most likely a bug introduced into
+		 * <a href=
+		 * "https://github.com/imagej/ImageJA/commit/a534b8f#diff-3cda9bab45abece23447b8321c867f67R841"
+		 * >version 1.38u of June 15th 2007</a>: The intention was probably to
+		 * set <code>recorderOn = false;</code> <it>before</it> running the
+		 * dialog listener, and setting it to <code>true</code> afterwards.
+		 * Being in effect for almost 8 years as of time of writing, it is
+		 * likely that users now rely on that behavior, though, so it should not
+		 * be changed now.
+		 */
+		final DialogListener listener = new DialogListener() {
+			@Override
+			public boolean dialogItemChanged(final GenericDialog gd,
+					final AWTEvent e) {
+				builder.append("value: ").append(gd.getNextString())
+						.append("\nevent: ").append(e).append("\n");
+				return true;
+			}
+		};
+		gd.addDialogListener(listener);
+		gd.showDialog();
+		if (gd.wasCanceled())
+			return;
+		builder.append("final value: ").append(gd.getNextString()).append("\n");
+	}
+
+	@Override
+	public String toString() {
+		return builder.toString();
+	}
+}


### PR DESCRIPTION
It was indirectly pointed out by @StephanPreibisch that plugins that have at least one attached `DialogListener` need to enquire all dialog values in the final call to the listener (i.e. when the `event` parameters is `null`) in order to be macro-recordable. After that, the `showDialog()` method returns and while it does not record the macro values afterwards, it still allows to run through them again. We need to support this usage in the headless mode, too.