### PR TITLE
LegacyExtensions: update YesNoCancelDialog constructor

### DIFF
--- a/src/main/java/net/imagej/patcher/LegacyExtensions.java
+++ b/src/main/java/net/imagej/patcher/LegacyExtensions.java
@@ -416,7 +416,11 @@ class LegacyExtensions {
 		} else {
 			hacker.replaceAppNameInCall("ij.plugin.Options", "public void appearance()", "showMessage", 2, appName);
 		}
-		hacker.replaceAppNameInCall("ij.gui.YesNoCancelDialog", "public <init>(java.awt.Frame parent, java.lang.String title, java.lang.String msg)", "super", 2, appName);
+		if (hacker.hasMethod("ij.gui.YesNoCancelDialog", "public <init>(java.awt.Frame parent, java.lang.String title, java.lang.String msg, java.lang.String yesLabel, java.lang.String noLabel)")) {
+			hacker.replaceAppNameInCall("ij.gui.YesNoCancelDialog", "public <init>(java.awt.Frame parent, java.lang.String title, java.lang.String msg, java.lang.String yesLabel, java.lang.String noLabel)", "super", 2, appName);
+		} else {
+			hacker.replaceAppNameInCall("ij.gui.YesNoCancelDialog", "public <init>(java.awt.Frame parent, java.lang.String title, java.lang.String msg)", "super", 2, appName);
+		}
 		hacker.replaceAppNameInCall("ij.gui.Toolbar", "private void showMessage(int toolId)", "showStatus", 1, appName);
 	}
 


### PR DESCRIPTION
ImageJ 1.51j has introduced a new [`YesNoCancelDialog` constructor](https://github.com/imagej/ImageJA/blob/eeaa405d6116ae3d48750a548cf71ce4f6b39d0a/src/main/java/ij/gui/YesNoCancelDialog.java#L17) that's not handled properly.

Also, I was only able to get the tests running by compiling once without running tests and subsequently doing:
```
$ mvn test -DargLine="-javaagent:target/ij1-patcher-0.12.6-SNAPSHOT.jar=init"
```

All tests w.r.t. to `YesNoCancelDialog` are passing with

```
Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.853 sec <<< FAILURE! - in net.imagej.patcher.HeadlessCompletenessTest
missingGenericDialogMethods(net.imagej.patcher.HeadlessCompletenessTest)  Time elapsed: 0.008 sec  <<< FAILURE!
java.lang.AssertionError: getInstance() is not overridden
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at net.imagej.patcher.HeadlessCompletenessTest.missingGenericDialogMethods(HeadlessCompletenessTest.java:158)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:367)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:274)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:161)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:290)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:242)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:121)
```

This will also partly fix http://forum.imagej.net/t/fiji-imagej-takes-too-long-to-load-on-linux-together-with-a-lengthy-error-message/4628, i.e. the exception should be fixed.