### PR TITLE
HeadlessCompletenessTest: exempt getInstance()

### DIFF
--- a/src/test/java/net/imagej/patcher/HeadlessCompletenessTest.java
+++ b/src/test/java/net/imagej/patcher/HeadlessCompletenessTest.java
@@ -127,6 +127,7 @@ public class HeadlessCompletenessTest {
 			"actionPerformed(java.awt.event.ActionEvent)", //
 			"adjustmentValueChanged(java.awt.event.AdjustmentEvent)", //
 			"getInsets(int,int,int,int)", //
+			"getInstance()", //
 			"getValue(java.lang.String)", //
 			"isMacro()", //
 			"isMatch(java.lang.String,java.lang.String)", //


### PR DESCRIPTION
ij-1.51i has introduced `ij.gui.GenericDialog.getInstance` to its public API. This will method will also work when ImageJ is executed in headless mode. Hence, there is no need to check for that method to be overridden.