### PR TITLE
Adapt to code changes introduced in 1.52q through 1.53b

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<license.projectName>ImageJ software for multidimensional image processing and analysis.</license.projectName>
 		<ij1-patcher.jar>${project.build.directory}/${project.build.finalName}.jar</ij1-patcher.jar>
 
-		<imagej1.version>1.53a</imagej1.version>
+		<imagej1.version>1.53b</imagej1.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<license.projectName>ImageJ software for multidimensional image processing and analysis.</license.projectName>
 		<ij1-patcher.jar>${project.build.directory}/${project.build.finalName}.jar</ij1-patcher.jar>
 
-		<imagej1.version>1.52t</imagej1.version>
+		<imagej1.version>1.53a</imagej1.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,8 @@ Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
 Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<license.projectName>ImageJ software for multidimensional image processing and analysis.</license.projectName>
 		<ij1-patcher.jar>${project.build.directory}/${project.build.finalName}.jar</ij1-patcher.jar>
+
+		<imagej1.version>1.52t</imagej1.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>27.0.1</version>
+		<version>28.0.0</version>
 		<relativePath />
 	</parent>
 
 	<groupId>net.imagej</groupId>
 	<artifactId>ij1-patcher</artifactId>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>ImageJ 1.x Patcher</name>
 	<description>A runtime patcher to introduce extension points into ImageJ 1.x. This project offers extension points for use with ImageJ2 and it also offers (limited) support for headless operations.</description>

--- a/src/main/java/net/imagej/patcher/CodeHacker.java
+++ b/src/main/java/net/imagej/patcher/CodeHacker.java
@@ -1130,6 +1130,18 @@ class CodeHacker {
 		clazz.instrument(new ExprEditor() {
 
 			@Override
+			public void edit(final ConstructorCall call) throws CannotCompileException {
+				try {
+					if (call.getConstructor().getLongName().equals("ij.gui.GenericDialog(java.lang.String,java.awt.Frame)")) {
+						call.replace("super();");
+					}
+				} catch (NotFoundException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+			}
+
+			@Override
 			public void edit(final NewExpr expr) throws CannotCompileException {
 				final String name = expr.getClassName();
 				if (name.startsWith("java.awt.Menu") ||

--- a/src/main/java/net/imagej/patcher/HeadlessGenericDialog.java
+++ b/src/main/java/net/imagej/patcher/HeadlessGenericDialog.java
@@ -40,6 +40,7 @@ import java.awt.Checkbox;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
+import java.awt.Frame;
 import java.awt.Insets;
 import java.awt.Panel;
 import java.awt.TextArea;
@@ -226,7 +227,7 @@ public class HeadlessGenericDialog {
     /**
      * Resets the counters before reading the dialog parameters.
      */
-	private void resetCounters() {
+	void resetCounters() {
 		numberfieldIndex = 0;
 		stringfieldIndex = 0;
 		checkboxIndex = 0;

--- a/src/main/java/net/imagej/patcher/HeadlessGenericDialog.java
+++ b/src/main/java/net/imagej/patcher/HeadlessGenericDialog.java
@@ -124,12 +124,16 @@ public class HeadlessGenericDialog {
 		choices.add(items[index]);
 	}
 
-	public void addNumericField(String label, double defaultValue, int digits) {
+	public void addNumericField(String label, double defaultValue) {
 		numbers.add(getMacroParameter(label, defaultValue));
 	}
 
+	public void addNumericField(String label, double defaultValue, int digits) {
+		addNumericField(label, defaultValue);
+	}
+
 	public void addNumericField(String label, double defaultValue, int digits, int columns, String units) {
-		addNumericField(label, defaultValue, digits);
+		addNumericField(label, defaultValue);
 	}
 
 	public void addSlider(String label, double minValue, double maxValue, double defaultValue) {
@@ -257,6 +261,7 @@ public class HeadlessGenericDialog {
 	public void setSmartRecording(boolean smartRecording) {}
 	public void enableYesNoCancel() {}
 	public void enableYesNoCancel(String yesLabel, String noLabel) {}
+	public void finalizeRecording() {}
 	public void focusGained(FocusEvent e) {}
 	public void focusLost(FocusEvent e) {}
 	public Button[] getButtons() { return null; }
@@ -279,6 +284,7 @@ public class HeadlessGenericDialog {
 	public void setOKLabel(String label) {}
 	protected void setup() {}
 	public void accessTextFields() {}
+	public void show() {}
 	public void showHelp() {}
 	public void setLocation(int x, int y) {}
 	public void setDefaultString(int index, String str) {}

--- a/src/main/java/net/imagej/patcher/LegacyHeadless.java
+++ b/src/main/java/net/imagej/patcher/LegacyHeadless.java
@@ -82,7 +82,7 @@ class LegacyHeadless  {
 			return;
 		}
 		hacker.commitClass(HeadlessGenericDialog.class);
-		hacker.replaceWithStubMethods("ij.gui.GenericDialog", "paint", "getInsets", "repaint", "showHelp");
+		hacker.replaceWithStubMethods("ij.gui.GenericDialog", "paint", "getInsets", "getParentFrame", "repaint", "showHelp");
 		hacker.replaceSuperclassAndStubifyAWTMethods("ij.gui.GenericDialog", HeadlessGenericDialog.class.getName());
 		hacker.skipAWTInstantiations("ij.gui.GenericDialog");
 
@@ -95,6 +95,8 @@ class LegacyHeadless  {
 		hacker.skipAWTInstantiations("ij.plugin.HyperStackConverter");
 
 		hacker.skipAWTInstantiations("ij.plugin.Duplicator");
+
+		hacker.skipAWTInstantiations("ij.gui.GUI");
 
 		hacker.insertAtTopOfMethod("ij.plugin.filter.ScaleDialog",
 			"java.awt.Panel makeButtonPanel(ij.plugin.filter.SetScaleDialog gd)",

--- a/src/test/java/net/imagej/patcher/HeadlessCompletenessTest.java
+++ b/src/test/java/net/imagej/patcher/HeadlessCompletenessTest.java
@@ -129,6 +129,7 @@ public class HeadlessCompletenessTest {
 			"adjustmentValueChanged(java.awt.event.AdjustmentEvent)", //
 			"getInsets(int,int,int,int)", //
 			"getInstance()", //
+			"getParentFrame()", //
 			"getValue(java.lang.String)", //
 			"isMacro()", //
 			"isMatch(java.lang.String,java.lang.String)", //

--- a/src/test/java/net/imagej/patcher/HeadlessCompletenessTest.java
+++ b/src/test/java/net/imagej/patcher/HeadlessCompletenessTest.java
@@ -129,7 +129,7 @@ public class HeadlessCompletenessTest {
 			"adjustmentValueChanged(java.awt.event.AdjustmentEvent)", //
 			"getInsets(int,int,int,int)", //
 			"getInstance()", //
-			"getParentFrame()", //
+			"getLabel()", //
 			"getValue(java.lang.String)", //
 			"isMacro()", //
 			"isMatch(java.lang.String,java.lang.String)", //


### PR DESCRIPTION
Three new method signatures were added to the `ij.gui.GenericDialog` class:
* `addNumericField(String, double)`
* `finalizeRecording()`
* `show()`

This PR fixes compatibility with `ij-1.52r.jar`, which is the version defined in `pom-scijava-28.0.0`. A new release of `ij1-patcher` is required and `pom-scijava-28.0.1` should be released with pinning to that new release to fix incompatible managed versions.
