### PR TITLE
Use Context's classLoader instead of Thread.currentThread().contextClassLoader()

### DIFF
--- a/src/main/java/net/imagej/patcher/LegacyInjector.java
+++ b/src/main/java/net/imagej/patcher/LegacyInjector.java
@@ -371,7 +371,9 @@ public class LegacyInjector {
 	}
 
 	public static void preinit() {
-		preinit(Thread.currentThread().getContextClassLoader());
+		ClassLoader cl = Thread.currentThread().getContextClassLoader();
+		if (cl == null) cl = ClassLoader.getSystemClassLoader();
+		preinit(cl);
 	}
 
 	public static void preinit(ClassLoader classLoader) {


### PR DESCRIPTION
We want to ensure that we have a `ClassLoader` in `LegacyInjector`. We can get a `null` `ClassLoader` from `Thread.currentThread().contextClassLoader()` by, for example, starting up ImageJ from a new thread in Python (using pyimagej). This should fix that issue.

See [this SO post](https://stackoverflow.com/questions/225594/thread-getcontextclassloader-null)

Unfortunately, this requires a dependency on scijava-common :frowning: