### PR TITLE
JPMS-safe getClasspathElements()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,11 @@
 			<artifactId>ij</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.github.classgraph</groupId>
+			<artifactId>classgraph</artifactId>
+			<version>4.8.162</version>
+		</dependency>
+		<dependency>
 			<groupId>org.javassist</groupId>
 			<artifactId>javassist</artifactId>
 		</dependency>


### PR DESCRIPTION
This PR introduces a new `getClasspathElements()` function in `LegacyHooks`. This version is based on ClassGraph, embarrassingly simple (as the heavy lifting is done by ClassGraph), and JPMS-safe. This means that most of the tests now also work on Java >= 17 👍 